### PR TITLE
Update injected.html

### DIFF
--- a/live-server/injected.html
+++ b/live-server/injected.html
@@ -16,7 +16,7 @@
 			}
 		}
 		var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
-		var address = protocol + window.location.host + window.location.pathname + '/ws';
+		var address = protocol + window.location.host + window.location.pathname.replace(/\/+$/, '') + '/ws';
 		var socket = new WebSocket(address);
 		socket.onmessage = function(msg) {
 			if (msg.data == 'reload') window.location.reload()


### PR DESCRIPTION
In most browsers, window.location.pathname already contain slash "/" at the end of the path. therefore `window.location.pathname + '/ws'` create double slash in the path such as "ws://example.com//ws". Which is not perfect.

And if I put a gateway server in front of live server, such as golang http handler, will automaticly cleanPath and return a 301 if the path contain double slash.

This pr is trying to make this right by removing the ending slash, if there is any, before '/ws' is appended.

remove duplicated slash in WebSocket path (from ws://example.com//ws to ws://example.com/ws)
