### PR TITLE
use custom browser

### DIFF
--- a/lib/atom-live-server.coffee
+++ b/lib/atom-live-server.coffee
@@ -13,12 +13,12 @@ module.exports = AtomLiveServer =
   subscriptions: null
 
   config:
-    openInApp:
+    openInBrowser:
       type: 'string'
       default: 'system'
-      title: 'Open in App'
+      title: 'Open in Browser'
       description: '''
-      Open the website in this app when starting the live-server.
+      Open the website in this browser when starting the live-server.
       Possible options are:
       'safari'
       'google chrome'
@@ -72,7 +72,7 @@ module.exports = AtomLiveServer =
       port: port,
       root: projectPath,
       open: true,
-      browser: atom.config.get("atom-live-server.openInApp")
+      browser: atom.config.get("atom-live-server.openInBrowser")
     };
 
     allowUnsafeEval -> liveServer.start params;

--- a/lib/atom-live-server.coffee
+++ b/lib/atom-live-server.coffee
@@ -12,6 +12,21 @@ liveServer =  allowUnsafeEval -> require "../live-server"
 module.exports = AtomLiveServer =
   subscriptions: null
 
+  config:
+    openInApp:
+      type: 'string'
+      default: 'system'
+      title: 'Open in App'
+      description: '''
+      Open the website in this app when starting the live-server.
+      Possible options are:
+      'safari'
+      'google chrome'
+      'firefox'
+      'firefoxdeveloperedition'
+      ...
+      '''
+
   activate: (state) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace', {
@@ -56,7 +71,8 @@ module.exports = AtomLiveServer =
     params = {
       port: port,
       root: projectPath,
-      open: true
+      open: true,
+      browser: atom.config.get("atom-live-server.openInApp")
     };
 
     allowUnsafeEval -> liveServer.start params;

--- a/live-server/index.js
+++ b/live-server/index.js
@@ -109,6 +109,7 @@ LiveServer.start = function(options) {
 	var file = options.file;
 	var staticServerHandler = staticServer(root);
 	var wait = options.wait || 0;
+	var browser = options.browser;
 
 	// Setup a web server
 	var app = connect()
@@ -142,8 +143,13 @@ LiveServer.start = function(options) {
 		}
 
 		// Launch browser
-		if (openPath !== null)
-			open(serveURL + openPath);
+		if (openPath !== null) {
+			if (browser === 'system' || browser === '') {
+				open(serveURL + openPath);
+			} else {
+				open(serveURL + openPath, browser);
+			}
+		}
 	});
 
 	// Setup server to listen at port


### PR DESCRIPTION
Added an option in the settings-menu to set a custom browser.
This may be useful if your daily browser (system-default) is not your development browser.