### PR TITLE
Migrate over to BufferNodeProcess to resolve Node path issues

### DIFF
--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -3,13 +3,12 @@
 import path from 'path';
 import fs from 'fs';
 import url from 'url';
-import { BufferedProcess, CompositeDisposable } from 'atom';
+import { BufferedNodeProcess, CompositeDisposable } from 'atom';
 import { remote } from 'electron';
 import JSON5 from 'json5';
 
 const packagePath = atom.packages.resolvePackagePath('atom-live-server');
 const liveServer = path.join(packagePath, '/node_modules/live-server/live-server.js');
-const node = path.resolve(process.env.NODE_PATH, '../../app/apm/bin/node');
 
 let serverProcess;
 let disposeMenu;
@@ -125,15 +124,13 @@ export default {
         args.push(`--port=${port}`);
       }
 
-      args.unshift(liveServer);
-
-      serverProcess = new BufferedProcess({
-        command: node,
+      serverProcess = new BufferedNodeProcess({
+        command: liveServer,
         args,
         stdout,
         exit,
         options: {
-          cwd: targetPath,
+          cwd: targetPath
         }
       });
 


### PR DESCRIPTION
Closes #86, #98, #105, #106, #108, #109

What this does it is migrates us from using BufferedProcess which is just a generic class that allow us to run commands, and instead uses BufferNodeProcess with uses the built-in Node for Atom.

By doing this it allows us to let Atom deal with the path issues and all of that for now and in the future, so that we don't need to keep manipulate it everything things keep breaking.

There are two reasons why this stopped working, some global paths like `atom-ide` would get appended to the `NODE_PATH` variable and break the link. Additionally, when they released v1.21.0 they restored Atom's "ASAR" archive functionality which messed up the original path.

This removes all of the path stuff from the plugin, so it should be far more stable in the future as well as resolve a lot of issues people are having currently with using the plugin.