### PR TITLE
Safely kill server process

### DIFF
--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -171,7 +171,7 @@ export default {
   },
 
   stopServer() {
-    if (serverProcess != null) {
+    if (serverProcess) {
       try {
         serverProcess.kill();
       } catch (e) {

--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -171,13 +171,14 @@ export default {
   },
 
   stopServer() {
-    try {
-      serverProcess.kill();
-    } catch (e) {
-      console.error(e);
+    if (serverProcess != null) {
+      try {
+        serverProcess.kill();
+      } catch (e) {
+        console.error(e);
+      }
+      serverProcess = null;
     }
-
-    serverProcess = null;
     const disposeStopMenu = disposeMenu;
     addStartMenu();
     disposeStopMenu && disposeStopMenu.dispose();


### PR DESCRIPTION
Before - would cause exceptions that would prevent atom from reloading.