### PR TITLE
Better arg condition and add config option for default port

### DIFF
--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -75,7 +75,7 @@ export default {
     return new Disposable(() => { console = null; });
   },
 
-  startServer(port = 3000) {
+  startServer(port = atom.config.get('atom-live-server.defaultPort') || 3000) {
     if (serverProcess) {
       return;
     }
@@ -155,7 +155,7 @@ export default {
         });
       }
 
-      if (!args.length) {
+      if (!args.some(e => e.match(/^--port=.*$/))) {
         args.push(`--port=${port}`);
       }
 
@@ -188,5 +188,13 @@ export default {
     atom.notifications.addSuccess('[Live Server] Live server is stopped.');
     console.info('[Live Server] Live server is stopped.')
     safeStatus('stopped');
+  },
+
+  config: {
+    defaultPort: {
+      type: 'integer',
+      description: 'The port used when atom-live-server is started without any arguments',
+      default: 3000
+    }
   }
 };

--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -88,7 +88,8 @@ export default {
     const targetPath = atom.project.getPaths()[0];
 
     if (!targetPath) {
-      atom.notifications.addWarning('[Live Server] You haven\'t opened a Project, you must open one.')
+      atom.notifications.addWarning('[Live Server] You haven\'t opened a Project, you must open one.');
+      stopServer();
       return;
     }
 
@@ -194,7 +195,9 @@ export default {
     defaultPort: {
       type: 'integer',
       description: 'The port used when atom-live-server is started without any arguments',
-      default: 3000
+      default: 3000,
+      minimum: 1,
+      maximum: 65535
     }
   }
 };


### PR DESCRIPTION
@jas-chen There's three ways to set the port

Through keyboard shortcut/command - This overrides everything
Through .atom-live-server.json - This overrides config setting and is specific to the project
Through config setting [new] - only used when default command is used (startServer) and no .atom-live-server.json is found.