### PR TITLE
Update atom-live-server.js

### DIFF
--- a/lib/atom-live-server.js
+++ b/lib/atom-live-server.js
@@ -146,6 +146,11 @@ export default {
               noBrowser = true;
             }
           }
+          else if (key === 'no-css-inject') {
+            if (userConfig[key] === true) {
+              args.push(`--${key}`);
+            }
+          }
           else if (key === 'root') {
               args.unshift(`${userConfig[key]}`)
             }


### PR DESCRIPTION
extends support for live-server `--no-css-inject` command line option.

You can add `"no-css-inject":true` to .atom-live.server.json in order to refresh the browser page on css file changes instead of injection.
This can prevent loading order and style rules overlapping issue when you save a css files and preview an html page with same rules in style tags.